### PR TITLE
Canonical meta tag in blog posts

### DIFF
--- a/components/layout/layoutBlog.js
+++ b/components/layout/layoutBlog.js
@@ -7,12 +7,12 @@ import path from "path";
 import NextImage from "next/image";
 
 const myLoader = ({ src, width, quality }) => {
-    return `${src}?w=${width}&q=${quality || 75}`;
+  return `${src}?w=${width}&q=${quality || 75}`;
 };
 
 const MDXComponents = {
   a: Link,
-  NextImage: (props) => <NextImage loader={myLoader} {...props}  />,
+  NextImage: (props) => <NextImage loader={myLoader} {...props}  />, // cannot use real NextImage, because it doesn't work in static export
 };
 export default function LayoutBlog({ title, seo, layout, ...props }) {
   const router = useRouter();
@@ -33,16 +33,15 @@ export default function LayoutBlog({ title, seo, layout, ...props }) {
   return (
     <>
       <NextSeo
-        title="Handout materials for Hands-on with Design Systems Workshop"
-        description="All the necessary documentation for the participants of the workshop"
-        keywords="design systems, workshop, team work, ReactJS, Figma, styled-components, Storybook, design, frontend, development"
-        // canonical={canonical}
+        title="Our Blog - GoRight"
+        description="Sharing our knowledge and experience"
         openGraph={{
           type: "website",
           locale: "en_IE",
-          url: "https://hands-on-workshop.goright.io/handout",
+          url: "https://goright.io/blog",
           site_name: "GoRight.io",
         }}
+        {...seo}
       />
       <div className="flex-grow py-8 bg-white border-b">
         <div className="flex bg-white min-w-100">

--- a/components/layout/layoutHandout.js
+++ b/components/layout/layoutHandout.js
@@ -2,6 +2,8 @@ import { MDXProvider } from "@mdx-js/react";
 import Link from "@components/link";
 import { Text, CtaLink } from "@goright/design-system";
 import { useRouter } from "next/router";
+import { NextSeo } from "next-seo";
+
 
 const MDXComponents = {
   a: Link,

--- a/components/layout/layoutHandout.js
+++ b/components/layout/layoutHandout.js
@@ -31,6 +31,18 @@ export default function HandoutLayout({
 
   return (
     <>
+      <NextSeo
+        title="Handout materials for Hands-on with Design Systems Workshop"
+        description="All the necessary documentation for the participants of the workshop"
+        keywords="design systems, workshop, team work, ReactJS, Figma, styled-components, Storybook, design, frontend, development"
+        openGraph={{
+          type: "website",
+          locale: "en_IE",
+          url: "https://hands-on-workshop.goright.io/handout",
+          site_name: "GoRight.io",
+        }}
+        {...seo}
+      />
       <div className="flex-grow py-8 bg-white border-b">
         <div className="flex bg-white min-w-100">
           <div className="container max-w-2xl py-2 mx-auto mb-8 text-xl text-left">

--- a/pages/blog/designers-developers-study/index.mdx
+++ b/pages/blog/designers-developers-study/index.mdx
@@ -7,6 +7,8 @@ seo:
     What do UX designers and UI developers value in each other? This research study on
     LinkedIn data analyses recommendation texts and bridges the results to the existing
     scientific and industry knowledge.
+  canonical: https://varya.me/blog/designers-developers-linkedin-study/
+
 ---
 
 


### PR DESCRIPTION
So, according Google, we need to use canonical tag again - it's valid cross domain as well. It can be added under seo -> canonical on frontmatter now.
A note: watch a blank line before closing "---". For some reason parser is breaking, if it is omitted.

Also Google docs point to [this tool](https://search.google.com/search-console/welcome) for checking canonical URL validity - but I cannot use it myself, because it requires authorization via DNS.